### PR TITLE
feat: multiple winners support

### DIFF
--- a/src/main.cairo
+++ b/src/main.cairo
@@ -87,7 +87,7 @@ mod QuestBoost {
         fn create_boost(
             ref self: ContractState, boost_id: u128, amount: u256, token: ContractAddress
         ) {
-            // check if boost_id is blacklisted
+            // check if boost_id is already created
             let boostMap_data = self.boostMap.read(boost_id);
             assert(!boostMap_data, 'boost already created');
 

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -35,7 +35,8 @@ mod QuestBoost {
 
     #[storage]
     struct Storage {
-        blacklist: LegacyMap::<felt252, bool>,
+        blacklist: LegacyMap::<u128, bool>,
+        blacklistSignature: LegacyMap::<felt252, bool>,
         boostMap: LegacyMap::<u128, bool>,
         public_key: felt252,
         #[substorage(v0)]
@@ -132,9 +133,13 @@ mod QuestBoost {
             let r = *signature.at(0);
             let s = *signature.at(1);
 
-            // check if signature is blacklisted
-            let blacklist_data = self.blacklist.read(r);
+            // check if boost_id is blacklisted
+            let blacklist_data = self.blacklist.read(boost_id);
             assert(!blacklist_data, 'blacklisted');
+
+            // check if signature is blacklisted
+            let blacklist_data_sign = self.blacklistSignature.read(r);
+            assert(!blacklist_data_sign, 'blacklisted');
 
             // check if signature is valid
             let caller: ContractAddress = get_caller_address();
@@ -152,7 +157,7 @@ mod QuestBoost {
             );
 
             // add r to the blacklist
-            self.blacklist.write(r, true);
+            self.blacklistSignature.write(r, true);
 
             // transfer tokens from contract to caller
             let starknet_erc20 = IERC20CamelDispatcher { contract_address: token };

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -138,8 +138,8 @@ mod QuestBoost {
             assert(!blacklist_data, 'blacklisted');
 
             // check if signature is blacklisted
-            let blacklist_data_sign = self.blacklistSignature.read(r);
-            assert(!blacklist_data_sign, 'blacklisted');
+            let blacklisted_sign = self.blacklistSignature.read(r);
+            assert(!blacklisted_sign, 'blacklisted');
 
             // check if signature is valid
             let caller: ContractAddress = get_caller_address();

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -35,7 +35,7 @@ mod QuestBoost {
 
     #[storage]
     struct Storage {
-        blacklist: LegacyMap::<u128, bool>,
+        blacklist: LegacyMap::<felt252, bool>,
         boostMap: LegacyMap::<u128, bool>,
         public_key: felt252,
         #[substorage(v0)]
@@ -133,7 +133,7 @@ mod QuestBoost {
             let s = *signature.at(1);
 
             // check if signature is blacklisted
-            let blacklist_data = self.blacklist.read(boost_id);
+            let blacklist_data = self.blacklist.read(r);
             assert(!blacklist_data, 'blacklisted');
 
             // check if signature is valid
@@ -152,7 +152,7 @@ mod QuestBoost {
             );
 
             // add r to the blacklist
-            self.blacklist.write(boost_id, true);
+            self.blacklist.write(r, true);
 
             // transfer tokens from contract to caller
             let starknet_erc20 = IERC20CamelDispatcher { contract_address: token };

--- a/src/tests/boost_contract.cairo
+++ b/src/tests/boost_contract.cairo
@@ -167,7 +167,29 @@ fn test_withdraw_all_not_owner() {
 #[test]
 #[available_gas(20000000000)]
 #[should_panic(expected: ('blacklisted', 'ENTRYPOINT_FAILED',))]
-fn test_duplicate_claim() {
+fn test_duplicate_claim_with_id() {
+    let quest_boost = deploy_contract();
+    let erc20 = deploy_token(quest_boost.contract_address, 10000);
+    let amount: u256 = 1000;
+    let token_id: ContractAddress = erc20.contract_address;
+    set_contract_address(ADMIN());
+    let (sig_0, sig_1) = (
+        765301107836623957948028135212947639996218756476579369944383988832488039190,
+        364743106737423797092878139014999646784167567917477096350335031799658835871
+    );
+    let boost_id = 1;
+    erc20.approve(ADMIN(), amount);
+    // make first valid call
+    quest_boost.claim(amount, token_id, boost_id, array![sig_0, sig_1].span());
+
+    // make second call with same signature
+    quest_boost.claim(amount, token_id, boost_id, array![sig_0, sig_1].span());
+}
+
+#[test]
+#[available_gas(20000000000)]
+#[should_panic(expected: ('blacklisted', 'ENTRYPOINT_FAILED',))]
+fn test_duplicate_claim_with_signature() {
     let quest_boost = deploy_contract();
     let erc20 = deploy_token(quest_boost.contract_address, 10000);
     let amount: u256 = 1000;

--- a/src/tests/boost_contract.cairo
+++ b/src/tests/boost_contract.cairo
@@ -164,3 +164,24 @@ fn test_withdraw_all_not_owner() {
     quest_boost.withdraw_all(token_id);
 }
 
+#[test]
+#[available_gas(20000000000)]
+#[should_panic(expected: ('blacklisted', 'ENTRYPOINT_FAILED',))]
+fn test_duplicate_claim() {
+    let quest_boost = deploy_contract();
+    let erc20 = deploy_token(quest_boost.contract_address, 10000);
+    let amount: u256 = 1000;
+    let token_id: ContractAddress = erc20.contract_address;
+    set_contract_address(ADMIN());
+    let (sig_0, sig_1) = (
+        765301107836623957948028135212947639996218756476579369944383988832488039190,
+        364743106737423797092878139014999646784167567917477096350335031799658835871
+    );
+    let boost_id = 1;
+    erc20.approve(ADMIN(), amount);
+    // make first valid call
+    quest_boost.claim(amount, token_id, boost_id, array![sig_0, sig_1].span());
+
+    // make second call with same signature
+    quest_boost.claim(amount, token_id, boost_id, array![sig_0, sig_1].span());
+}


### PR DESCRIPTION
We blacklist `r` now since we need to add multiple winners support. Blacklisting by `boost_id` only works when we require a single winner but fails when multiple winners come up. With this we blacklist the `r` value of the ecdsa signature which is unique and will be used to identify duplicate requests