### PR TITLE
feat: allow to rotate keys

### DIFF
--- a/src/interface.cairo
+++ b/src/interface.cairo
@@ -11,7 +11,7 @@ trait IQuestBoost<TContractState> {
     );
     fn create_boost(ref self: TContractState, boost_id: u128, amount: u256, token: ContractAddress);
     fn withdraw_all(ref self: TContractState, token: ContractAddress);
-
+    fn update_pub_key(ref self: TContractState, new_pub_key: felt252);
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
     fn get_balance(self: @TContractState, token: ContractAddress) -> u256;
 }

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -124,8 +124,7 @@ mod QuestBoost {
         }
 
         fn update_pub_key(ref self: ContractState, new_pub_key: felt252) {
-            let caller: ContractAddress = get_caller_address();
-            assert(caller == self.ownable.owner(), 'only admin can change key');
+            self.ownable.assert_only_owner();
             self.public_key.write(new_pub_key);
         }
 

--- a/src/main.cairo
+++ b/src/main.cairo
@@ -123,6 +123,12 @@ mod QuestBoost {
             assert(transfer_result, 'transfer failed');
         }
 
+        fn update_pub_key(ref self: ContractState, new_pub_key: felt252) {
+            let caller: ContractAddress = get_caller_address();
+            assert(caller == self.ownable.owner(), 'only admin can change key');
+            self.public_key.write(new_pub_key);
+        }
+
         fn claim(
             ref self: ContractState,
             amount: u256,


### PR DESCRIPTION
This pull request allows the admin to change the pub key of the contract.